### PR TITLE
make HashTableSeparateChaining get and remove methods a little DRYer …

### DIFF
--- a/chapter07/05-HashCollisionSeparateChaining.js
+++ b/chapter07/05-HashCollisionSeparateChaining.js
@@ -41,17 +41,12 @@ function HashTableSeparateChaining(){
             //iterate linked list to find key/value
             var current = table[position].getHead();
 
-            while(current.next){
+            do {
                 if (current.element.key === key){
                     return current.element.value;
                 }
                 current = current.next;
-            }
-
-            //check in case first or last element
-            if (current.element.key === key){
-                return current.element.value;
-            }
+            } while(current);
         }
         return undefined;
     };
@@ -65,7 +60,7 @@ function HashTableSeparateChaining(){
             //iterate linked list to find key/value
             var current = table[position].getHead();
 
-            while(current.next){
+            do {
                 if (current.element.key === key){
                     table[position].remove(current.element);
                     if (table[position].isEmpty()){
@@ -74,16 +69,7 @@ function HashTableSeparateChaining(){
                     return true;
                 }
                 current = current.next;
-            }
-
-            //check in case first or last element
-            if (current.element.key === key){
-                table[position].remove(current.element);
-                if (table[position].isEmpty()){
-                    table[position] = undefined;
-                }
-                return true;
-            }
+            } while(current);
         }
 
         return false;


### PR DESCRIPTION
…using do ... while instead of while loop

Hi Loiane! Thank you for taking a look at and merging my previous PR. Here's another one for you to consider. If you use a `do ... while` loop instead of just a `while` loop in the `get()` and `remove()` methods you can make the code a little DRYer/succinct. `do ... while` loops are somewhat obscure/less common, but I think can work well here. They will execute at least once, and evaluate their conditional at the bottom of the loop instead of at the top like most other loops.