### PR TITLE
fix bug in CircularLinkedList

### DIFF
--- a/chapter05/05-CircularLinkedList.js
+++ b/chapter05/05-CircularLinkedList.js
@@ -46,16 +46,22 @@ function CircularLinkedList() {
                 index = 0;
 
             if (position === 0){ //add on first position
+                
+                if(!head){ // if no node  in list
+                    head = node;
+                    node.next = head;
+                }else{
+                    node.next = current;
 
-                node.next = current;
+                    //update last element
+                    while(current.next !== head){ //last element will be head instead of NULL
+                        current = current.next;
+                    }
 
-                //update last element
-                while(current.next !== head){ //last element will be head instead of NULL
-                    current = current.next;
+                    head = node;
+                    current.next = head;
                 }
-
-                head = node;
-                current.next = head;
+                
 
             } else {
                 while (index++ < position){
@@ -181,3 +187,4 @@ function CircularLinkedList() {
         console.log(this.toString());
     };
 }
+

--- a/chapter05/05-CircularLinkedList2.js
+++ b/chapter05/05-CircularLinkedList2.js
@@ -58,15 +58,18 @@ let CircularLinkedList2 = (function () {
 
               if (position === 0) { //add on first position
 
-                    node.next = current;
-
-                    //update last element
-                    while (current.next !== this.getHead()) { //last element will be head instead of NULL
-                        current = current.next;
-                    }
-
-                    head.set(this, node);
-                    current.next = this.getHead();
+                  if(!this.getHead()) { // if no node  in list
+                      head.set(this, node);
+                      node.next = this.getHead();
+                  } else {
+                      node.next = current;
+                      //update last element
+                      while(current.next !== this.getHead()) { //last element will be head instead of NULL
+                          current = current.next;
+                      }
+                      head.set(this, node);
+                      current.next = this.getHead();
+                  }
 
                 } else {
                     while (index++ < position) {


### PR DESCRIPTION
There is a bug in insert function. If you insert an element in an empty
list at the first  position. It will throw a TypeError: Cannot read
property 'next' of null.
