### PR TITLE
removed unused variable in Doubly linked list and amended insert method

### DIFF
--- a/chapter05/03-DoublyLinkedList2.js
+++ b/chapter05/03-DoublyLinkedList2.js
@@ -23,7 +23,7 @@ let DoublyLinkedList2 = (function () {
         append(element) {
 
             let node = new Node(element),
-                current, _tail;
+                _tail;
 
             if (this.getHead() === null) { //first node on list
                 head.set(this, node);
@@ -54,7 +54,7 @@ let DoublyLinkedList2 = (function () {
 
                 if (position === 0) { //add on first position
 
-                    if (!this.getHead()) {       //NEW
+                    if (!current) {       //NEW
                         head.set(this, node);
                         tail.set(this, node);
                     } else {

--- a/chapter06/01-Set2.js
+++ b/chapter06/01-Set2.js
@@ -55,7 +55,7 @@ let Set2 = (function () {
         }
 
         union(otherSet){
-            let unionSet = new Set();
+            let unionSet = new Set2();
 
             let values = this.values();
             for (let i=0; i<values.length; i++){
@@ -71,7 +71,7 @@ let Set2 = (function () {
         }
 
         intersection(otherSet){
-            let intersectionSet = new Set();
+            let intersectionSet = new Set2();
 
             let values = this.values();
             for (let i=0; i<values.length; i++){
@@ -84,7 +84,7 @@ let Set2 = (function () {
         }
 
         difference(otherSet){
-            let differenceSet = new Set();
+            let differenceSet = new Set2();
 
             let values = this.values();
             for (let i=0; i<values.length; i++){


### PR DESCRIPTION
append method of doubly linked list had unused current variable - removed same.
in insert method of doubly linked list, for position === 0, we check if its !this.getHead(). however, this.getHead() is already available in current variable, hence instead we can just check !current