### PR TITLE
linked-list-models.js : wrote more javascript manner

### DIFF
--- a/src/js/data-structures/models/linked-list-models.js
+++ b/src/js/data-structures/models/linked-list-models.js
@@ -1,12 +1,16 @@
-export class Node {
-  constructor(element, next) {
+export var Node = (function () {
+  function Node(element, next) {
     this.element = element;
     this.next = next;
   }
-}
-export class DoublyNode extends Node {
-  constructor(element, next, prev) {
-    super(element, next);
+  return Node;
+}());
+
+export var DoublyNode = (function () {
+  function DoublyNode(element, next, prev) {
     this.prev = prev;
+    Node.call(this, element, next);
   }
-}
+
+  return DoublyNode;
+}());


### PR DESCRIPTION
* I rewrote the classes ```Node``` and ```DoublyNode``` in javascript manner. Because the keywords ```class```, ```extended``` , ```constructor``` etc. aren't standardized in javascript. 