### PR TITLE
fix: multiple elements to push to stack-array.js

### DIFF
--- a/src/js/data-structures/stack-array.js
+++ b/src/js/data-structures/stack-array.js
@@ -5,8 +5,10 @@ export default class StackArray {
     this.items = [];
   }
 
-  push(element) {
-    this.items.push(element);
+  push() {
+    for (let i in arguments) {
+      this.items.push(arguments[i]);
+    }
   }
 
   pop() {


### PR DESCRIPTION
In a stack, push method must be able to be added to the top of the stack even if multiple elements are written in (). However, only one element of the original code can be pushed. Therefore, I request a correction.

