### PR TITLE
Enable Dependabot for npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      dev-dependencies:
+        dependency-type: "development"


### PR DESCRIPTION
## Summary

Adds a `.github/dependabot.yml` configuration to enable Dependabot version updates for this repository.

## Details

- **npm ecosystem** rooted at `/` (where `package.json` lives).
- **Weekly** update schedule.
- Dev dependencies **grouped** into a single PR to reduce noise.
- Open PR limit of 10.

No GitHub Actions workflows exist in the repo, so only the `npm` ecosystem is configured. Once merged to the default branch, GitHub will automatically start running Dependabot.

> Note: GitHub also reported 2 existing vulnerabilities (1 moderate, 1 low) on the default branch — enabling Dependabot will help surface and address these going forward.