### PR TITLE
Add CI workflow to run tests on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.x, 22.x, 24.x]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [24.x]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow (`.github/workflows/test.yml`) that runs the Jest test suite automatically on every pull request targeting `main` (and on pushes to `main`). This lets the repo's tests gate PRs before they're merged.

## What it does

- Triggers on `pull_request` and `push` to `main`.
- Runs `npm ci` then `npm test` (Jest via `ts-jest`).
- Runs on **Node 24.x**.
- Uses npm dependency caching for faster runs.

## Notes on JS + TS

The repo contains both JavaScript and TypeScript. All current test files are `*.test.ts` and are executed by Jest through the `ts-jest` preset, so `npm test` already covers the TypeScript sources. The plain `.js` files are example/illustration scripts without their own test files; they are still importable/runnable by the same Jest setup if `.test.js` files are added later (Jest's default `testMatch` picks up both `.js` and `.ts`).

## Why tests only (not `tsc` build)

I intentionally did **not** add `npm run build:ts` (full `tsc`) as a required step. The build currently fails on pre-existing TypeScript errors in the `leetcode` example files (e.g. duplicate global `TreeNode` / `TrieNode` declarations and script-style redeclarations). Gating PRs on the build would block every PR until those are refactored into modules. That cleanup is out of scope here — happy to tackle it in a separate PR if you'd like.

## Enforcing this before merge

The workflow makes the test run **visible** on every PR, but to actually **block merging** on failure you'll also need a branch protection (or ruleset) rule on `main` requiring the `Test (Node 24.x)` status check to pass. I can't configure that via code — it's a repo setting. Let me know if you'd like guidance on the exact settings.