### PR TITLE
Remove @ts-ignore comments in 03-array by fixing root causes

### DIFF
--- a/src/03-array/02-adding-removing-elements.ts
+++ b/src/03-array/02-adding-removing-elements.ts
@@ -1,6 +1,6 @@
 // Path: src/03-array/02-adding-removing-elements.ts
+export {};
 
-// @ts-ignore
 let numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 
 numbers[numbers.length] = 10;

--- a/src/03-array/03-iterator-functions.ts
+++ b/src/03-array/03-iterator-functions.ts
@@ -1,6 +1,6 @@
 // Path: src/03-array/03-iterator-functions.ts
+export {};
 
-// @ts-ignore
 const numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
 // using forEach method
@@ -38,7 +38,6 @@ for (let i = 0; i < numbers.length; i++) {
 }
 
 // using filter method
-// @ts-ignore
 const valuesBelowSeven = numbers.filter(value => value < 7);
 console.log('Values below 7:', valuesBelowSeven); // [1, 2, 3, 4, 5, 6]
 

--- a/src/03-array/04-searching-sorting.ts
+++ b/src/03-array/04-searching-sorting.ts
@@ -1,6 +1,6 @@
 // Path: src/03-array/04-searching-sorting.ts
+export {};
 
-// @ts-ignore
 const numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
 // using indexOf method
@@ -36,7 +36,6 @@ if (bookIndex !== -1) {
 }
 
 // using the filter method in the numbers array
-// @ts-ignore
 const valuesBelowSeven = numbers.filter(value => value < 7);
 console.log('Values below 7:', valuesBelowSeven); // [1, 2, 3, 4, 5, 6]
 
@@ -49,8 +48,7 @@ numbers.sort(); // [1, 10, 2, 3, 4, 5, 6, 7, 8, 9]
 
 numbers.sort((a, b) => a - b); // [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
-// @ts-ignore
-function compareNumbers(a, b) { 
+function compareNumbers(a: number, b: number): number { 
     if (a < b) { 
       return -1; 
     } 
@@ -65,19 +63,20 @@ function compareNumbers(a, b) {
 console.log('Sorted numbers:', numbers); // [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
 // custom sorting
-// @ts-ignore
-const friends = [ 
+interface Friend {
+  name: string;
+  age: number;
+}
+const friends: Friend[] = [ 
   { name: 'Frodo', age: 30 }, 
   { name: 'Violet', age: 18 }, 
   { name: 'Aelin', age: 20 } 
 ]; 
-// @ts-ignore
-const compareFriends = (friendA, friendB) => friendA.age - friendB.age;
+const compareFriends = (friendA: Friend, friendB: Friend) => friendA.age - friendB.age;
 friends.sort(compareFriends);
 console.log('Sorted friends:', friends); // [ { name: 'Violet', age: 18 }, { name: 'Aelin', age: 20 }, { name: 'Frodo', age: 30 } ]
 
 // sorting strings
-// @ts-ignore
 let names = ['Ana', 'ana', 'john', 'John']; 
 console.log(names.sort());  // ['Ana', 'John', 'ana', 'john']
 

--- a/src/03-array/05-transforming-array.ts
+++ b/src/03-array/05-transforming-array.ts
@@ -1,6 +1,6 @@
 // Path: src/03-array/05-transforming-array.ts
+export {};
 
-// @ts-ignore
 const numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
 // using the map method
@@ -15,7 +15,6 @@ for (let i = 0; i < numbers.length; i++) {
 
 // using the split method
 const namesFromCSV = 'Aelin,Gandalf,Violet,Poppy';
-// @ts-ignore
 const names = namesFromCSV.split(',');
 console.log('Names:', names); // ['Aelin', 'Gandalf', 'Violet', 'Poppy']
 
@@ -24,14 +23,13 @@ const namesCSV = names.join(';');
 console.log('Names CSV:', namesCSV); // 'Aelin;Gandalf;Violet;Poppy'
 
 // using the reduce method
-// @ts-ignore
-const numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-const sum = numbers.reduce((acc, value) => acc + value, 0); // 55
+const numbersForReduce = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+const sum = numbersForReduce.reduce((acc, value) => acc + value, 0); // 55
 
 // rewriting the above code using a loop
 let sumLoop = 0;
-for (let i = 0; i < numbers.length; i++) {
-  sumLoop += numbers[i];
+for (let i = 0; i < numbersForReduce.length; i++) {
+  sumLoop += numbersForReduce[i];
 }
 
 // using the reduce method to find the maximum value
@@ -39,7 +37,7 @@ const scores = [30, 70, 85, 90, 100];
 const highestScore = scores.reduce((max, score) => score > max ? score : max, scores[0]); // 100
 
 // using reduceRight method
-const reversedNumbers = numbers.reduceRight((acc: number[], value) => {
+const reversedNumbers = numbersForReduce.reduceRight((acc: number[], value) => {
   acc.push(value);
   return acc;
 }, [] as number[]); // [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]

--- a/src/03-array/06-other-methods.ts
+++ b/src/03-array/06-other-methods.ts
@@ -1,4 +1,5 @@
 // Path: src/03-array/06-other-methods.ts
+export {};
 
 // using Array.isArray() method
 console.log(typeof 'Learning Data Structures'); // string
@@ -26,7 +27,6 @@ if (Array.isArray(dataReceived)) {
 }
 
 // using Array.from() method
-// @ts-ignore
 const numbers = [1, 2, 3, 4, 5];
 const numbersCopy = Array.from(numbers);
 console.log(numbersCopy); // [1, 2, 3, 4, 5]
@@ -35,7 +35,6 @@ const evens = Array.from(numbers, x => (x % 2 == 0));
 console.log(evens); // [false, true, false, true, false]
 
 // Array.from() method creates a new, shallow-copied Array instance from an array-like or iterable object.
-// @ts-ignore
 const friends = [ 
   { name: 'Frodo', age: 30 }, 
   { name: 'Violet', age: 18 }, 

--- a/src/03-array/07-multidimensional-arrays.ts
+++ b/src/03-array/07-multidimensional-arrays.ts
@@ -31,8 +31,7 @@ averageTempMultipleDays[1][3] = 75;
 averageTempMultipleDays[1][4] = 73;
 averageTempMultipleDays[1][5] = 73;
 
-// @ts-ignore
-function printMultidimensionalArray(myArray) {
+function printMultidimensionalArray(myArray: number[][]): void {
   for (let i = 0; i < myArray.length; i++) {
     for (let j = 0; j < myArray[i].length; j++) {
       console.log(myArray[i][j]);

--- a/src/03-array/09-arrays-typescript.ts
+++ b/src/03-array/09-arrays-typescript.ts
@@ -1,18 +1,17 @@
 // Path: src/03-array/09-arrays-typescript.ts
+export {};
 
 interface Friend { 
   name: string; 
   age: number; 
 } 
 
-// @ts-ignore
-const friends = [ 
+const friends: Friend[] = [ 
   { name: 'Frodo', age: 30 }, 
   { name: 'Violet', age: 18 }, 
   { name: 'Aelin', age: 20 } 
 ];
 
-// @ts-ignore
 const compareFriends = (friendA: Friend, friendB: Friend) => { 
   return friendA.age - friendB.age; 
 };


### PR DESCRIPTION
Removes all spurious `@ts-ignore` comments from `src/03-array/` by fixing the underlying type issues properly.

## Root causes & fixes

### Duplicate identifiers across files (most of the `@ts-ignore` instances)
Multiple files all declared `const numbers`, `const friends`, `const names` at the top level. Because none had `import`/`export`, TypeScript treated them as scripts sharing global scope, causing identifier conflicts.

**Fix:** Added `export {}` to 6 files to make each a proper module with its own scope:
- `02-adding-removing-elements.ts`
- `03-iterator-functions.ts`
- `04-searching-sorting.ts`
- `05-transforming-array.ts`
- `06-other-methods.ts`
- `09-arrays-typescript.ts`

### Double declaration in same file
`05-transforming-array.ts` declared `const numbers` twice. The second declaration (used for `reduce` examples) was renamed to `const numbersForReduce`.

### Untyped function parameters
- `compareNumbers(a, b)` in `04-searching-sorting.ts` → typed as `(a: number, b: number): number`
- `compareFriends(friendA, friendB)` → typed using a local `Friend` interface
- `printMultidimensionalArray(myArray)` in `07-multidimensional-arrays.ts` → typed as `number[][]`

### Also typed
- `friends` in `09-arrays-typescript.ts` → typed as `Friend[]`

## What was intentionally kept
All `@ts-ignore` comments on the `Array.prototype` extensions in `02-adding-removing-elements.ts` are retained — those are educational examples of prototype extension.