### PR TITLE
Fix CommonJS/TypeScript constructor interop in deque + heap sort

### DIFF
--- a/src/05-queue-deque/palindrome-checker.js
+++ b/src/05-queue-deque/palindrome-checker.js
@@ -1,4 +1,5 @@
-const Deque = require('./deque.js');
+const DequeModule = require('./deque.js');
+const Deque = DequeModule.default || DequeModule;
 
 function isPalindrome(word) {
 

--- a/src/11-heap/heap-sort.js
+++ b/src/11-heap/heap-sort.js
@@ -1,6 +1,7 @@
 // src/11-heap/heap-sort.js
 
-const Comparator = require('../10-tree/comparator.js');
+const ComparatorModule = require('../10-tree/comparator.js');
+const Comparator = ComparatorModule.default || ComparatorModule;
 
 /**
  * Heapify the array.


### PR DESCRIPTION
## Summary
- fix `Deque` import handling in `src/05-queue-deque/palindrome-checker.js` to support both CommonJS and transpiled default-export module shapes
- fix `Comparator` import handling in `src/11-heap/heap-sort.js` with the same compatibility pattern
- preserve existing module APIs while eliminating runtime `TypeError: ... is not a constructor` failures

## Why
Some modules are transpiled with `exports.default`, while these consumers expected direct CommonJS constructor exports. That mismatch caused failing queue/deque and heap-sort test suites.

## Validation
- affected tests now pass:
  - `src/05-queue-deque/__test__/algorithms.test.js`
  - `src/05-queue-deque/__test__/algorithms.test.ts`
  - `src/11-heap/__test__/heap-sort.test.js`
  - `src/11-heap/__test__/heap-sort.test.ts`
- TypeScript build succeeds (`npm run build:ts`)